### PR TITLE
Use package:pubspec_parse

### DIFF
--- a/lib/src/models/pub_package_model.dart
+++ b/lib/src/models/pub_package_model.dart
@@ -1,5 +1,5 @@
 import 'package:freezed_annotation/freezed_annotation.dart';
-import 'package:pubspec/pubspec.dart';
+import 'package:pubspec_parse/pubspec_parse.dart';
 
 // import 'package:pubspec_parse/pubspec_parse.dart';
 
@@ -24,7 +24,7 @@ abstract class PubPackage implements _$PubPackage {
   String get description => latestPubspec.description ?? '';
   String get url => 'https://pub.dev/packages/$name';
   String get changelogUrl => '$url/changelog';
-  PubSpec get latestPubspec => latest.pubspec;
+  Pubspec get latestPubspec => latest.pubspec;
 }
 
 /// Package Version Model
@@ -33,7 +33,7 @@ class PackageVersion with _$PackageVersion {
   @JsonSerializable(fieldRename: FieldRename.snake)
   factory PackageVersion({
     required String version,
-    required PubSpec pubspec,
+    required Pubspec pubspec,
     required String archiveUrl,
     required DateTime published,
   }) = _PackageVersion;

--- a/lib/src/models/pub_package_model.freezed.dart
+++ b/lib/src/models/pub_package_model.freezed.dart
@@ -231,7 +231,7 @@ class _$PackageVersionTearOff {
 
   _PackageVersion call(
       {required String version,
-      required PubSpec pubspec,
+      required Pubspec pubspec,
       required String archiveUrl,
       required DateTime published}) {
     return _PackageVersion(
@@ -253,7 +253,7 @@ const $PackageVersion = _$PackageVersionTearOff();
 /// @nodoc
 mixin _$PackageVersion {
   String get version => throw _privateConstructorUsedError;
-  PubSpec get pubspec => throw _privateConstructorUsedError;
+  Pubspec get pubspec => throw _privateConstructorUsedError;
   String get archiveUrl => throw _privateConstructorUsedError;
   DateTime get published => throw _privateConstructorUsedError;
 
@@ -269,7 +269,7 @@ abstract class $PackageVersionCopyWith<$Res> {
           PackageVersion value, $Res Function(PackageVersion) then) =
       _$PackageVersionCopyWithImpl<$Res>;
   $Res call(
-      {String version, PubSpec pubspec, String archiveUrl, DateTime published});
+      {String version, Pubspec pubspec, String archiveUrl, DateTime published});
 }
 
 /// @nodoc
@@ -296,7 +296,7 @@ class _$PackageVersionCopyWithImpl<$Res>
       pubspec: pubspec == freezed
           ? _value.pubspec
           : pubspec // ignore: cast_nullable_to_non_nullable
-              as PubSpec,
+              as Pubspec,
       archiveUrl: archiveUrl == freezed
           ? _value.archiveUrl
           : archiveUrl // ignore: cast_nullable_to_non_nullable
@@ -317,7 +317,7 @@ abstract class _$PackageVersionCopyWith<$Res>
       __$PackageVersionCopyWithImpl<$Res>;
   @override
   $Res call(
-      {String version, PubSpec pubspec, String archiveUrl, DateTime published});
+      {String version, Pubspec pubspec, String archiveUrl, DateTime published});
 }
 
 /// @nodoc
@@ -346,7 +346,7 @@ class __$PackageVersionCopyWithImpl<$Res>
       pubspec: pubspec == freezed
           ? _value.pubspec
           : pubspec // ignore: cast_nullable_to_non_nullable
-              as PubSpec,
+              as Pubspec,
       archiveUrl: archiveUrl == freezed
           ? _value.archiveUrl
           : archiveUrl // ignore: cast_nullable_to_non_nullable
@@ -375,7 +375,7 @@ class _$_PackageVersion implements _PackageVersion {
   @override
   final String version;
   @override
-  final PubSpec pubspec;
+  final Pubspec pubspec;
   @override
   final String archiveUrl;
   @override
@@ -420,7 +420,7 @@ class _$_PackageVersion implements _PackageVersion {
 abstract class _PackageVersion implements PackageVersion {
   factory _PackageVersion(
       {required String version,
-      required PubSpec pubspec,
+      required Pubspec pubspec,
       required String archiveUrl,
       required DateTime published}) = _$_PackageVersion;
 
@@ -430,7 +430,7 @@ abstract class _PackageVersion implements PackageVersion {
   @override
   String get version;
   @override
-  PubSpec get pubspec;
+  Pubspec get pubspec;
   @override
   String get archiveUrl;
   @override

--- a/lib/src/models/pub_package_model.g.dart
+++ b/lib/src/models/pub_package_model.g.dart
@@ -26,7 +26,7 @@ Map<String, dynamic> _$$_PubPackageToJson(_$_PubPackage instance) =>
 _$_PackageVersion _$$_PackageVersionFromJson(Map<String, dynamic> json) =>
     _$_PackageVersion(
       version: json['version'] as String,
-      pubspec: PubSpec.fromJson(json['pubspec'] as Map<String, dynamic>?),
+      pubspec: Pubspec.fromJson(json['pubspec'] as Map<String, dynamic>),
       archiveUrl: json['archive_url'] as String,
       published: DateTime.parse(json['published'] as String),
     );

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -12,7 +12,7 @@ dependencies:
   json_annotation: ^4.4.0
   oauth2: ^2.0.0
   path: ^1.8.0
-  pubspec: ^2.0.1
+  pubspec_parse: ^1.2.0
 
 dev_dependencies:
   build_runner: ^2.0.1

--- a/test/helpers_test.dart
+++ b/test/helpers_test.dart
@@ -2,7 +2,7 @@ import 'dart:io';
 
 import 'package:pub_api_client/src/pub_api_client_base.dart';
 import 'package:pub_api_client/src/version.dart';
-import 'package:pubspec/pubspec.dart';
+import 'package:pubspec_parse/pubspec_parse.dart';
 import 'package:test/test.dart';
 
 const packageName = 'fvm';
@@ -16,7 +16,7 @@ void main() {
     });
 
     test('Does Package version match', () async {
-      final pubspec = PubSpec.fromYamlString(File(
+      final pubspec = Pubspec.parse(File(
         '${Directory.current.path}/pubspec.yaml',
       ).readAsStringSync());
       expect(pubspec.version.toString(), packageVersion);


### PR DESCRIPTION
This is a proposal to replace [`package:pubspec`](https://pub.dev/packages/pubspec) by [`package:pubspec_parse`](https://pub.dev/packages/pubspec_parse). 
`pubspec_parse` is a package owned by the Dart team and seems to have a better quality score.
Also it exposes more fields (like `repository`, `issueTracker`...)

