### PR TITLE
Loosen constraint on `collection` for Flutter

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -7,7 +7,7 @@ environment:
   sdk: ">=2.17.0 <3.0.0"
 
 dependencies:
-  collection: ^1.17.0
+  collection: ^1.16.0
   http: ^0.13.5
 
   oauth2: ^2.0.1


### PR DESCRIPTION
```console
Running "flutter pub get" in pub_stats...                       
Because every version of flutter_test from sdk depends on collection 1.16.0 and pub_api_client >=2.3.0 depends on collection ^1.17.0, flutter_test from sdk is incompatible with pub_api_client >=2.3.0.
So, because pub_stats depends on both pub_api_client ^2.3.0 and flutter_test from sdk, version solving failed.
pub get failed (1; So, because pub_stats depends on both pub_api_client ^2.3.0 and flutter_test from sdk, version solving failed.)
```