### PR TITLE
Add the ability to search with any tags

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,10 +152,17 @@ final like =  await client.unlikePackage('pkg_name');
 
 ### Search Packages
 
-Search for packages on pub.dev. Will return the packages that match the query. You can filter the search to a specific `publisher`, or packages with a certain `dependency`.
+Search for packages on pub.dev. Will return the packages that match the query. You can filter the search with tags.
 
 ```dart
-final results =  await client.search('query', publisher:'publisher_id', dependency:'dependency_name');
+final results =  await client.search(
+  'query',
+  tags: [
+    PackageTag.publisher('publisher_id'),
+    PackageTag.dependency('dependency_name'),
+    'another:tag',
+  ],
+);
 // Returns the packages that match the query
 print(results.packages)
 ```

--- a/lib/src/constants.dart
+++ b/lib/src/constants.dart
@@ -88,3 +88,73 @@ class EnvironmentNotFoundException implements Exception {
   @override
   String toString() => message;
 }
+
+// ignore: avoid_classes_with_only_static_members
+/// Tags used for filtering package searches
+class PackageTag {
+  /// Filter by publisher
+  static String publisher(String publisher) => 'publisher:$publisher';
+
+  /// Filter by dependency
+  static String dependency(String dependency) => 'dependency:$dependency';
+
+  /// Filter packages that are something
+  static String isTag(String isTag) => 'is:$isTag';
+
+  /// Filter packages by supported platform
+  static String platform(String platform) => 'platform:$platform';
+
+  /// Filter packages by sdk
+  static String sdk(String sdk) => 'sdk:$sdk';
+
+  /// Filter packages by license
+  static String license(String license) => 'license:$license';
+
+  /// Show packages that are something
+  static String show(String show) => 'show:$show';
+
+  /// Filter packages that have something
+  static String has(String has) => 'has:$has';
+
+  /// Supports android platform
+  static String platformAndroid = platform('android');
+
+  /// Supports ios platform
+  static String platformIos = platform('ios');
+
+  /// Supports linux platform
+  static String platformLinux = platform('linux');
+
+  /// Supports macos platform
+  static String platformMacos = platform('macos');
+
+  /// Supports web platform
+  static String platformWeb = platform('web');
+
+  /// Supports windows platform
+  static String platformWindows = platform('windows');
+
+  /// Uses dart sdk
+  static String sdkDart = sdk('dart');
+
+  /// Uses flutter sdk
+  static String sdkFlutter = sdk('flutter');
+
+  /// Uses an OSI approved license
+  static String licenseOsiApproved = license('osi-approved');
+
+  /// Is a flutter favorite
+  static String isFlutterFavorite = isTag('flutter-favorite');
+
+  /// Show unlisted packages
+  static String showUnlisted = show('unlisted');
+
+  /// Is null-safe
+  static String isNullSafe = isTag('null-safe');
+
+  /// Has screenshots
+  static String hasScreenshot = has('screenshot');
+
+  /// Is Dart 3 ready
+  static String isDart3Ready = isTag('dart3-ready');
+}

--- a/lib/src/pub_api_client_base.dart
+++ b/lib/src/pub_api_client_base.dart
@@ -131,7 +131,7 @@ class PubClient {
   }
 
   /// Searches pub for [query] and can [page] results.
-  /// Can specify [tags] to filter results.
+  /// Can specify [tags] to filter results. See [PackageTag] for details.
   /// returns `SearchResults`
   Future<SearchResults> search(
     String query, {

--- a/lib/src/pub_api_client_base.dart
+++ b/lib/src/pub_api_client_base.dart
@@ -214,7 +214,8 @@ class PubClient {
 
   /// Retrieves all the flutter favorites
   Future<List<String>> fetchFlutterFavorites() async {
-    final searchResults = await search('is:flutter-favorite');
+    final searchResults =
+        await search('', tags: [PackageTag.isFlutterFavorite]);
     final results = await recursivePaging(this, searchResults);
     return results.map((r) => r.package).toList();
   }

--- a/test/pubdev_api_test.dart
+++ b/test/pubdev_api_test.dart
@@ -109,9 +109,10 @@ void main() {
     });
 
     test('Search for packages of a publisher', () async {
-      final payload = await client.search('', publisher: 'fvm.app');
-      final nextPagePayload =
-          await client.search('', dependency: 'pub_api_client');
+      final payload =
+          await client.search('', tags: [PackageTag.publisher('fvm.app')]);
+      final nextPagePayload = await client
+          .search('', tags: [PackageTag.dependency('pub_api_client')]);
       expect(payload.packages.length, greaterThan(0));
       expect(nextPagePayload.packages.length, greaterThan(0));
     });


### PR DESCRIPTION
This also adds the convenience class `PackageTag` to create tags with a known structure.

Note that this is a breaking change since the fields for `publisher` and `dependency` have been removed in favor of the new `tags` field.